### PR TITLE
Fix appsync/api gateway integration example

### DIFF
--- a/apigateway-appsync-integration/README.md
+++ b/apigateway-appsync-integration/README.md
@@ -14,7 +14,13 @@ More about it [here](https://docs.localstack.cloud/user-guide/aws/appsync/#graph
 
 ### Run
 
+Start LocalStack with a specific endpoint configuration:
+
+```bash
+GRAPHQL_ENDPOINT_STRATEGY=domain localstack start
 ```
+
+```bash
 ./run.sh
 ```
 

--- a/apigateway-appsync-integration/main.tf
+++ b/apigateway-appsync-integration/main.tf
@@ -252,7 +252,7 @@ resource "aws_dynamodb_table_item" "example_item" {
   hash_key   = aws_dynamodb_table.table.hash_key
   item       = <<ITEM
   {
-    "id": { "S": "2"},
+    "id": { "S": "1"},
     "title": { "S": "Post Title" }
   }
 ITEM

--- a/apigateway-appsync-integration/run.sh
+++ b/apigateway-appsync-integration/run.sh
@@ -7,4 +7,4 @@ rm terraform.tfstate* || true
 tflocal init; tflocal apply --auto-approve
 
 restapi=$(aws apigateway --endpoint-url=http://localhost:4566 get-rest-apis | jq -r .items[0].id)
-curl -X POST "$restapi.execute-api.localhost.localstack.cloud:4566/dev/graphql"
+curl -X POST "http://$restapi.execute-api.us-east-1.localhost.localstack.cloud:4566/dev/graphql"

--- a/apigateway-appsync-integration/run.sh
+++ b/apigateway-appsync-integration/run.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
+set -euo pipefail
 set -x
 
-tflocal init; tflocal plan; tflocal apply --auto-approve
+rm terraform.tfstate* || true
+tflocal init; tflocal apply --auto-approve
 
 restapi=$(aws apigateway --endpoint-url=http://localhost:4566 get-rest-apis | jq -r .items[0].id)
 curl -X POST "$restapi.execute-api.localhost.localstack.cloud:4566/dev/graphql"


### PR DESCRIPTION
The API Gateway/AppSync integration example is not working on either AWS nor LocalStack for the following reasons:

* the item inserted into the database is not matched by the fetch call
* the `run.sh` script did not include the region in the URL (nor the scheme but that was not a critical problem)
* LocalStack needed to be configured to use a specific AppSync endpoint strategy to work

In addition, this PR updates the run script to be more robust to errors, and to clear the terraform state before running. This makes repeated runs nicer to use.
